### PR TITLE
Ensure prompt_toolkit is less than version 3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ daiquiri
 paramiko
 watchdog
 semantic_version
-prompt_toolkit >= 2.0
+prompt_toolkit >=2.0,<3.0


### PR DESCRIPTION
`prompt_toolkit` versions >= 3.0 use the asyncio event loop natively, rather then using its own implementations of event loops. This causes the import statement on line 11 of `ui.py` in `faculty-sync` to fail. To prevent this from happening I have changed the requirements file to ensure the `prompt_toolkit` version is less than 3.0.

Alternatively, we could follow the solution suggested in the `prompt_toolkit` docs:

```
from prompt_toolkit import __version__ as ptk_version

PTK3 = ptk_version.startswith('3.')

if PTK3:
    from asyncio import get_event_loop
else:
    from prompt_toolkit.eventloop import get_event_loop
```